### PR TITLE
chore: add istanbul ignore to isIterable & isAsyncIterable

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -184,12 +184,12 @@ const utils = (() => {
     function isAsyncIterable(arg) {
         return (
             typeof arg === 'object' &&
-            arg !== null &&
-            asyncIteratorSymbol in arg &&
-            // istanbul ignore next
-            'next' in arg &&
-            // istanbul ignore next
-            typeof arg.next === 'function'
+                arg !== null &&
+                asyncIteratorSymbol in arg &&
+                // istanbul ignore next
+                'next' in arg &&
+                // istanbul ignore next
+                typeof arg.next === 'function'
         );
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -121,6 +121,7 @@ const utils = (() => {
             arg !== null &&
             iteratorSymbol in arg &&
             'next' in arg &&
+            // istanbul ignore next
             typeof arg.next === 'function'
         );
     }
@@ -183,10 +184,12 @@ const utils = (() => {
     function isAsyncIterable(arg) {
         return (
             typeof arg === 'object' &&
-                arg !== null &&
-                asyncIteratorSymbol in arg &&
-                'next' in arg &&
-                typeof arg.next === 'function'
+            arg !== null &&
+            asyncIteratorSymbol in arg &&
+            // istanbul ignore next
+            'next' in arg &&
+            // istanbul ignore next
+            typeof arg.next === 'function'
         );
     }
 


### PR DESCRIPTION
Making sure that we hit the 100% coverage & unlock npm build