### PR TITLE
chore: add master branch to semantic release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,7 +5,8 @@
       "prerelease": true,
       "range": "1.8.x",
       "channel": "fast"
-    }
+    },
+    {"name": "master"}
   ],
   "plugins": [
     "@semantic-release/commit-analyzer",


### PR DESCRIPTION
Trying to fix:

```
> semantic-release
[2:41:12 PM] [semantic-release] › ℹ  Running semantic-release version 19.0.3
[2:41:12 PM] [semantic-release] › ✔  Loaded plugin "verifyConditions" from "@semantic-release/npm"
[2:41:12 PM] [semantic-release] › ✔  Loaded plugin "analyzeCommits" from "@semantic-release/commit-analyzer"
[2:41:12 PM] [semantic-release] › ✔  Loaded plugin "prepare" from "@semantic-release/npm"
[2:41:12 PM] [semantic-release] › ✔  Loaded plugin "publish" from "@semantic-release/npm"
[2:41:12 PM] [semantic-release] › ✔  Loaded plugin "addChannel" from "@semantic-release/npm"
[2:41:14 PM] [semantic-release] › ✖  ERELEASEBRANCHES The release branches are invalid in the `branches` configuration.
A minimum of 1 and a maximum of 3 release branches are required in the branches configuration (https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#branches).
This may occur if your repository does not have a release branch, such as master.
Your configuration for the problematic branches is [].
AggregateError: 
    SemanticReleaseError: The release branches are invalid in the `branches` configuration.
        at module.exports (/home/runner/work/jsonata/jsonata/node_modules/semantic-release/lib/get-error.js:6:10)
        at /home/runner/work/jsonata/jsonata/node_modules/semantic-release/lib/branches/index.js:45:[19](https://github.com/Stedi/jsonata/runs/6814886571?check_suite_focus=true#step:6:20)
        at Array.reduce (<anonymous>)
        at module.exports (/home/runner/work/jsonata/jsonata/node_modules/semantic-release/lib/branches/index.js:35:46)
        at async run (/home/runner/work/jsonata/jsonata/node_modules/semantic-release/index.js:65:[22](https://github.com/Stedi/jsonata/runs/6814886571?check_suite_focus=true#step:6:23))
        at async module.exports (/home/runner/work/jsonata/jsonata/node_modules/semantic-release/index.js:[26](https://github.com/Stedi/jsonata/runs/6814886571?check_suite_focus=true#step:6:27)9:22)
        at async module.exports (/home/runner/work/jsonata/jsonata/node_modules/semantic-release/cli.js:55:5)
    at module.exports (/home/runner/work/jsonata/jsonata/node_modules/semantic-release/lib/branches/index.js:67:11)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at async run (/home/runner/work/jsonata/jsonata/node_modules/semantic-release/index.js:65:22)
    at async module.exports (/home/runner/work/jsonata/jsonata/node_modules/semantic-release/index.js:269:22)
    at async module.exports (/home/runner/work/jsonata/jsonata/node_modules/semantic-release/cli.js:55:5)npm ERR! code ELIFECYCLE
```