### PR TITLE
chore: fix releaserc

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,8 +6,7 @@
       "channel": "fast"
     },
     {
-      "name": "master",
-      "release": true
+      "name": "master"
     }
   ],
   "plugins": [


### PR DESCRIPTION
`release` is not a valid property of branches objects (anymore): https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#branches