### PR TITLE
chore: use stedi-main as release branch

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,12 +1,7 @@
 {
   "branches": [
     {
-      "name": "stedi-main",
-      "prerelease": true,
-      "channel": "fast"
-    },
-    {
-      "name": "master"
+      "name": "stedi-main"
     }
   ],
   "plugins": [


### PR DESCRIPTION
Previously we published a prerelease from the `stedi-main` branch. This gave us release versions like https://github.com/Stedi/jsonata/pkgs/npm/jsonata/35300857: `@stedi/jsonata:1.8.7-stedi-main.3`

After this change the release job should produce release versions like `@stedi/jsonata:2.0.1`.

I used `npm run release` locally to verify that the releaserc config is now valid.
