### PR TITLE
fix: trigger release

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,5 @@ In a browser:
 ## Contributing
 
 See the [CONTRIBUTING.md](CONTRIBUTING.md) for details of how to contribute to this repo.
+
+## test change for internal release


### PR DESCRIPTION
With this PR I'm trying to tell semantic release to retry the `npm run release` command and publish changes.

We previously had an [authentication failure](https://github.com/Stedi/jsonata/actions/runs/4124740474/jobs/7124367697) (401). I rotated my personal GitHub token which should not be related to this repo's release workflow which uses an organization secret. But after I rotated and restarted the release workflow, the logs told me that apparently the authentication is good now: https://github.com/Stedi/jsonata/actions/runs/4124740474/jobs/7126653973

I don't really trust this conclusion, but I'd like to try it nonetheless.