### PR TITLE
chore: fix releaserc

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,7 +1,9 @@
 {
   "branches": [
     {
-      "name": "stedi-main"
+      "name": "stedi-main",
+      "prerelease": true,
+      "channel": "fast"
     }
   ],
   "plugins": [


### PR DESCRIPTION
This reverts change in https://github.com/Stedi/jsonata/pull/25 - I'm not entirely sure why the release fails, but that should do the trick.