### PR TITLE
chore: reintroduce main branch to releaserc

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -4,6 +4,9 @@
       "name": "stedi-main",
       "prerelease": true,
       "channel": "fast"
+    },
+    {
+      "name": "main"
     }
   ],
   "plugins": [


### PR DESCRIPTION
```
[10:53:30 AM] [semantic-release] › ✖  ERELEASEBRANCHES The release branches are invalid in the `branches` configuration.
A minimum of 1 and a maximum of 3 release branches are required in the branches configuration (https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#branches).

This may occur if your repository does not have a release branch, such as master.

Your configuration for the problematic branches is [].

AggregateError: 
    SemanticReleaseError: The release branches are invalid in the `branches` configuration.
        at module.exports (/home/runner/work/jsonata/jsonata/node_modules/semantic-release/lib/get-error.js:6:10)
        at /home/runner/work/jsonata/jsonata/node_modules/semantic-release/lib/branches/index.js:45:19
        at Array.reduce (<anonymous>)
        at module.exports (/home/runner/work/jsonata/jsonata/node_modules/semantic-release/lib/branches/index.js:[35](https://github.com/Stedi/jsonata/actions/runs/4203034252/jobs/7291925355#step:8:36):46)
        at async run (/home/runner/work/jsonata/jsonata/node_modules/semantic-release/index.js:65:22)
        at async module.exports (/home/runner/work/jsonata/jsonata/node_modules/semantic-release/index.js:269:22)
        at async module.exports (/home/runner/work/jsonata/jsonata/node_modules/semantic-release/cli.js:55:5)
    at module.exports (/home/runner/work/jsonata/jsonata/node_modules/semantic-release/lib/branches/index.js:67:11)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at async run (/home/runner/work/jsonata/jsonata/node_modules/semantic-release/index.js:65:22)
    at async module.exports (/home/runner/work/jsonata/jsonata/node_modules/semantic-release/index.js:269:22)
    at async module.exports (/home/runner/work/jsonata/jsonata/node_modules/semantic-release/cli.js:55:5)npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @stedi/jsonata@2.0.1 release: `semantic-release`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the @stedi/jsonata@2.0.1 release script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2023-02-17T10_53_30_[49](https://github.com/Stedi/jsonata/actions/runs/4203034252/jobs/7291925355#step:8:50)4Z-debug.log
```