### PR TITLE
fix: do not run test workflow on merge to stedi-main

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,7 +1,5 @@
-name: Test JSONata
+name: Check
 on:
-    push:
-        branches: [stedi-main]
     pull_request:
         branches: [stedi-main]
 jobs:


### PR DESCRIPTION
The tests already runs in the publish workflow. No need to run them twice.