### PR TITLE
fix: undo type update

### DIFF
--- a/jsonata.d.ts
+++ b/jsonata.d.ts
@@ -20,7 +20,7 @@ declare namespace jsonata {
     steps?: ExprNode[];
     expressions?: ExprNode[];
     stages?: ExprNode[];
-    lhs?: ExprNode[];
+    lhs?: ExprNode;
     rhs?: ExprNode;
   }
 


### PR DESCRIPTION
An update to the TS definition in
https://github.com/jsonata-js/jsonata/pull/633 is causing issues in transformers-jsonata since we are using both 1.x and 2.x versions in there and types do not align anymore. Reverting the change for now. We overwrite the type of the NodeExpr in mappings anyway, and so this should be fine for now.