### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# CODEOWNERS
+# This file defines the individuals or teams responsible for code in this repository.
+# For more details, see: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for everything in the repo
+* @Stedi/engineering
+
+# Do not request review for dep-only upgrades
+package.json
+package-lock.json
+pnpm-lock.yaml
+**/package.json
+**/package-lock.json


### PR DESCRIPTION
This PR adds a CODEOWNERS file to define code ownership for the repository.